### PR TITLE
Add documentation for openbox addToCart link

### DIFF
--- a/source/includes/openbox/_category.md
+++ b/source/includes/openbox/_category.md
@@ -27,7 +27,8 @@ bby.openBox('categoryId=abcat0400000)').then(function(data){
       },
       "links": {
         "product": "http://api.bestbuy.com/v1/products/5729048.json?apiKey=YourAPIKey",
-        "web": "http://www.bestbuy.com/site/canon-ef-40mm-f-2-8-stm-standard-lens-black/5729048.p?id=1218688218296&skuId=5729048&cmp=RMX&ky=2l9pmD3wUBb9cc0tkHo49KBFCMPCiIPY4#tab=buyingOptions"
+        "web": "http://www.bestbuy.com/site/canon-ef-40mm-f-2-8-stm-standard-lens-black/5729048.p?id=1218688218296&skuId=5729048&cmp=RMX&ky=2l9pmD3wUBb9cc0tkHo49KBFCMPCiIPY4#tab=buyingOptions",
+        "addToCart": "https://api.bestbuy.com/click/-/5729048/cart"
       },
       "names": {
         "title": "Canon - EF 40mm f/2.8 STM Standard Lens - Black"

--- a/source/includes/openbox/_index.md.erb
+++ b/source/includes/openbox/_index.md.erb
@@ -23,6 +23,7 @@ Attribute | Description
 **images.standard** | URL of BESTBUY.COM product detail page image
 **links.product** | Link to the specific product in the Products API using a product identifier (SKU)
 **links.web** | Link to the BESTBUY.COM product detail page using the Buying Options tab
+**links.addToCart** | URL to BESTBUY.COM with item in cart
 **names.title** | Name of the product
 **offers.condition** | The condition attribute will either be "excellent" (products that look brand new in appearance,with no physical flaws, scratches or scuffs and include all original parts and accessories) or "certified" (products that have passed the Geek Squad Certification process)
 **offers.prices.current,** | "Open box" product's current selling price

--- a/source/includes/openbox/_multiple-skus.md
+++ b/source/includes/openbox/_multiple-skus.md
@@ -35,7 +35,8 @@ bby.openBox('sku in(5729048,7528703,4839357,8153056,8610161)').then(function(dat
       },
       "links": {
         "product": "http://api.bestbuy.com/v1/products/8610161.json?apiKey=YourAPIKey",
-        "web": "http://www.bestbuy.com/site/acer-11-6-chromebook-intel-celeron-2gb-memory-16gb-emmc-flash-memory-moonstone-white/8610161.p?id=1219351773817&skuId=8610161&cmp=RMX&ky=2l9pmD3wUBb9cc0tkHo49KBFCMPCiIPY4#tab=buyingOptions"
+        "web": "http://www.bestbuy.com/site/acer-11-6-chromebook-intel-celeron-2gb-memory-16gb-emmc-flash-memory-moonstone-white/8610161.p?id=1219351773817&skuId=8610161&cmp=RMX&ky=2l9pmD3wUBb9cc0tkHo49KBFCMPCiIPY4#tab=buyingOptions",
+        "addToCart": "https://api.bestbuy.com/click/-/8610161/cart"
       },
       "names": {
         "title": "Acer - 11.6\" Chromebook - Intel Celeron - 2GB Memory - 16GB eMMC Flash Memory - Moonstone White"

--- a/source/includes/openbox/_single-sku.md
+++ b/source/includes/openbox/_single-sku.md
@@ -26,7 +26,8 @@ bby.openBox(8610161).then(function(data){
       },
       "links": {
         "product": "http://api.bestbuy.com/v1/products/8610161.json?apiKey=YourAPIKey",
-        "web": "http://www.bestbuy.com/site/acer-11-6-chromebook-intel-celeron-2gb-memory-16gb-emmc-flash-memory-moonstone-white/8610161.p?id=1219351773817&skuId=8610161&cmp=RMX&ky=2l9pmD3wUBb9cc0tkHo49KBFCMPCiIPY4#tab=buyingOptions"
+        "web": "http://www.bestbuy.com/site/acer-11-6-chromebook-intel-celeron-2gb-memory-16gb-emmc-flash-memory-moonstone-white/8610161.p?id=1219351773817&skuId=8610161&cmp=RMX&ky=2l9pmD3wUBb9cc0tkHo49KBFCMPCiIPY4#tab=buyingOptions",
+        "addToCart": "https://api.bestbuy.com/click/-/8610161/cart"
       },
       "names": {
         "title": "Acer - 11.6\" Chromebook - Intel Celeron - 2GB Memory - 16GB eMMC Flash Memory - Moonstone White"


### PR DESCRIPTION
This adds the openbox `links.addToCart` attribute to the docs.