### PR TITLE
changes for ALL-MIX290

### DIFF
--- a/source/includes/products/_availability-and-delivery.md
+++ b/source/includes/products/_availability-and-delivery.md
@@ -8,13 +8,9 @@ Attribute | Description
 **friendsAndFamilyPickup** | Identifies if a product is eligible for friends and family pickup
 **homeDelivery** | Identifies if a product must be fulfilled using home delivery instead of shipping
 **inStoreAvailability** | Identifies if a product is available for purchase in a Best Buy store
-**inStoreAvailabilityText** | Additional information regarding inStoreAvailability
-**inStoreAvailabilityTextHtml** | Additional information regarding inStoreAvailability (HTML formatting)
 **inStoreAvailabilityUpdateDate** | Provides date and time inStoreAvailability last updated
 **inStorePickup** | Identifies if a product can be purchased online and picked up in a store
 **onlineAvailability** | Identifies if a product can be purchased online
-**onlineAvailabilityText** | Additional information regarding online availability
-**onlineAvailabilityTextHtml** | Additional information regarding online availability (HTML formatting)
 **onlineAvailabilityUpdateDate** | Provides date and time onlineAvailability was last updated
 **orderable** | Product ordering status
 **specialOrder** | Identifies whether a product will require special handling for delivery

--- a/source/includes/products/_detail.md
+++ b/source/includes/products/_detail.md
@@ -18,7 +18,6 @@ Attribute | Description | Type
 **digital** | Identifies if product is available in a digital format | boolean
 **features.feature** | Collection of product features | string
 **format** | Identifies media product format | string
-**frequentlyPurchasedWith.sku** | Collection of SKUs that are frequently purchased with originating SKU | long
 **height** | Product height (inches) | string
 **includedItemList.includedItem** | Collection of items included with product (Example: Canon EOS 60D Digital SLR Camera, EF-S 18-135mm IS lens, Battery pack, Battery charger) | string
 **longDescription** | Detailed product description | string
@@ -28,13 +27,18 @@ Attribute | Description | Type
 **name** | Product name | string
 **preowned** | Identifies if product has been previously owned (used) | boolean
 **quantityLimit** | Maximum quantity of product that can be ordered |integer
-**relatedProducts.sku** | Collection of SKUs that are similar to originating SKU | long
+**productVariations.sku** | Collection of related SKUs that are variaitions (e.g. color, size) of the originating SKU | long
 **releaseDate** | Date the product was released | date
 **shortDescription** | Brief product description | string
 **shortDescriptionHtml** | Brief product description (HTML formatting) | string
-**sku** | Best Buy unique product identifier | long
+**sku** | Best Buy unique 7-digit product identifier | long
 **upc** | Universal Product Code (UPC) | string
 **warrantyLabor** | Manufacture labor warranty description | string
 **warrantyParts** | Manufacture parts warranty description | string
 **weight** | Product weight | string
 **width** | Product width (inches) | string
+**discs.tracks** | Name and sequence for songs on a designated Music SKU | string
+**contracts.type** | Type of phone contract for activated device SKU| string
+**contracts.prices** | Regular and current monthly contract pricing for activated device SKU | long
+**contracts.priceNote** | Description of contract pricing for activated device SKU  | string
+

--- a/source/includes/products/_detail.md
+++ b/source/includes/products/_detail.md
@@ -26,8 +26,8 @@ Attribute | Description | Type
 **modelNumber** | Manufacturer product model number | string
 **name** | Product name | string
 **preowned** | Identifies if product has been previously owned (used) | boolean
+**productVariations.sku** | Collection of related SKUs that are variations (e.g. color, size) of the originating SKU | long
 **quantityLimit** | Maximum quantity of product that can be ordered |integer
-**productVariations.sku** | Collection of related SKUs that are variaitions (e.g. color, size) of the originating SKU | long
 **releaseDate** | Date the product was released | date
 **shortDescription** | Brief product description | string
 **shortDescriptionHtml** | Brief product description (HTML formatting) | string
@@ -37,8 +37,4 @@ Attribute | Description | Type
 **warrantyParts** | Manufacture parts warranty description | string
 **weight** | Product weight | string
 **width** | Product width (inches) | string
-**discs.tracks** | Name and sequence for songs on a designated Music SKU | string
-**contracts.type** | Type of phone contract for activated device SKU| string
-**contracts.prices** | Regular and current monthly contract pricing for activated device SKU | long
-**contracts.priceNote** | Description of contract pricing for activated device SKU  | string
 

--- a/source/includes/products/_pricing-and-ranking.md
+++ b/source/includes/products/_pricing-and-ranking.md
@@ -4,6 +4,9 @@ Best Buy's Pricing attributes make it easy to identify the product price, if a p
 Attribute | Description
 --------- | -----------
 **bestSellingRank** | Ranks products by number of units sold
+**contracts.type** | Type of contract for Mobile phone
+**contracts.prices** | Regular and current monthly contract pricing for Mobile phone
+**contracts.priceNote** | Description of contract pricing for Mobile phone
 **dollarSavings** | Identifies amount saved
 **lowPriceGuarantee** | Identifies if a product qualifies for the Best Buy low price guarantee
 **onSale** | Identifies if sale price is less than regular price
@@ -15,7 +18,7 @@ Attribute | Description
 **priceWithPlan.newTwoYearPlanSalePrice** | Mobile phone sale price when purchased with 2-year plan
 **priceWithPlan.upgradeTwoYearPlanSalePrice** | Mobile phone sale price when purchased with 2-year upgrade plan
 **priceWithPlan.newTwoYearPlanRegularPrice** | Mobile phone price when purchased with new 2-year plan
-**priceWithPlan.upgradeTwoYearPlanRegularPrice** | Mobile phone price when purchased with 2-year upgrade plan
+**priceWithPlan.upgradeTwoYearPlanRegularPrice** | Mobile phone price when purchased with 2-year upgrade plan  
 **regularPrice** | Product's regular selling price
 **salePrice** | Current item selling price
 **salesRankLongTerm** | Sales rank over past 5-21 days


### PR DESCRIPTION
updated documentation to include productVariations, music tracks and contract pricing attributes and remove the deprecated attributes for availability text, productFamilies and relatedProducts.
-also clarified that Best Buy SKus are 7 digit