### PR TITLE
Fixes typos in the list of [available operators](https://bestbuyapis.…

### DIFF
--- a/source/includes/search/_index.md
+++ b/source/includes/search/_index.md
@@ -8,10 +8,10 @@ Attribute *names* are case sensitive; attribute *values* are not.
 ## Available Operators
 
 + `=` - attribute **equals** a specified value
-+ `=!`- attribute **does not equal** a specified value
++ `!=`- attribute **does not equal** a specified value
 + `>` - attribute **greater than** a specified value
 + `<` - attribute **less than** a specified value
-+ `>=<` - attribute **greater than or equal to** a specified value
++ `>=` - attribute **greater than or equal to** a specified value
 + `<=` - attribute **less than or equal to** a specified value
 + `in` - search based on a **list** of attribute values
 


### PR DESCRIPTION
…github.io/api-documentation/#available-operators)

specifically, the NOT operator and GREATER THAN OR EQUAL TO
operators were listed incorrectly    #80  