### PR TITLE
Replace legacy email references with links to /contact-us

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for being interested in contributing to Best Buy's API!
 
 - If you find a bug or want to add a feature, create an issue on [GitHub](https://github.com/BestBuyAPIs/api-documentation)
-- If you have questions, you can email us at developer@bestbuy.com
+- If you have questions, you can [contact us](https://developer.bestbuy.com/contact-us)
 - If you'd like to learn more, please visit https://developer.bestbuy.com/
 
 # Contributing to Slate

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Check out [Slate](https://github.com/tripit/slate).
 Go to https://developer.bestbuy.com and click "Get API Key"
 
 #### How can I learn more about the Best Buy API?
-Visit https://developer.bestbuy.com or email developer@bestbuy.com
+Visit https://developer.bestbuy.com
 
 ## Getting Started with the Best Buy API Documentation
 *Yes, this is identical to getting started with Slate.*
@@ -35,7 +35,7 @@ Visit https://developer.bestbuy.com or email developer@bestbuy.com
 You can now see the docs at <http://localhost:4567>.
 
 ## Need Help? Found a bug?
-You can either [submit an issue](https://github.com/BestBuyAPIs/api-documentation/issues) or contact us at developer@bestbuy.com.
+You can either [submit an issue](https://github.com/BestBuyAPIs/api-documentation/issues) or [contact us](https://developer.bestbuy.com/contact-us).
 
 Once your issue has been resolved, the Best Buy team will publish the documentation changes (using `rake publish`).
 

--- a/source/includes/commerce/_index.md.erb
+++ b/source/includes/commerce/_index.md.erb
@@ -1,5 +1,5 @@
 # Commerce API
-The Best Buy Commerce API allows our partners to introduce a seamless cart experience to their customers, exposing the ability to select various fulfillment options including *Store Pickup* at one of our 1,400+ locations, *Ship To Home* and *Home Delivery*. If you have not yet been issued a Commerce API key, please contact [developer@bestbuy.com](mailto:developer@bestbuy.com).
+The Best Buy Commerce API allows our partners to introduce a seamless cart experience to their customers, exposing the ability to select various fulfillment options including *Store Pickup* at one of our 1,400+ locations, *Ship To Home* and *Home Delivery*. If you have not yet been issued a Commerce API key, please [contact us](https://developer.bestbuy.com/contact-us).
 
 Within the Commerce APIs, partners have the ability to integrate your e-commerce solution with Best Buy's online experience.
 
@@ -12,4 +12,4 @@ Full documentation supplied once you have a CAPI Key. Commerce API functionality
 * Modify/Cancel an Order
 
 ## Getting a Commerce API Key
-Please contact us at [developer@bestbuy.com](mailto:developer@bestbuy.com) to request an invite to the Commerce API program and a corresponding API Key. Current CAPI partners can access reporting and documentation via the same address.
+Please [contact us](https://developer.bestbuy.com/contact-us) to request an invite to the Commerce API program and a corresponding API Key. Current CAPI partners can access reporting and documentation via the same address.

--- a/source/includes/gettingstarted/_index.md.erb
+++ b/source/includes/gettingstarted/_index.md.erb
@@ -36,4 +36,4 @@ HINT: Don't forget to replace **YourAPIKey** with the API key that you received 
 ## Stay Connected
 Keep up with the latest changes in our APIs through our [release notes](https://developer.bestbuy.com/release-notes) and [blog](https://developer.bestbuy.com/blog).
 
-Have fun and please let us know what you think. Shoot us an email at **developer@bestbuy.com**, tweet us at [@BestBuyAPI](https://twitter.com/bestbuyapi) or hop on the [StackOverflow support forum](https://developer.bestbuy.com/support) and share your ideas on how we can deliver the best product. Let’s develop the future of retail together.
+Have fun and please let us know what you think. Tweet us at [@BestBuyAPI](https://twitter.com/bestbuyapi) or head over to our [support page](https://developer.bestbuy.com/support) and share your ideas on how we can deliver the best product. Let’s develop the future of retail together.

--- a/source/includes/overview/_index.md.erb
+++ b/source/includes/overview/_index.md.erb
@@ -4,8 +4,6 @@ Welcome to the Best Buy Developer API site! Whether you're an API pro, a beginni
 
 If this is your first time using our APIs, please check out our [Getting Started](http://developer.bestbuy.com/documentation/getting-started) guide. If you already have your API key, our Search and Response Formats can help you refine your results.
 
-*NOTE: Effective in early 2017, JSONP will be disabled in the interest of protecting user privacy. This will prevent developers making API calls from the client side and thus exposing API keys to the general public. If you have any questions or ideas on this issue, please contact us at developer@bestbuy.com.*
-
 <%= partial "includes/overview/responseFormat" %>
 <%= partial "includes/overview/show" %>
 <%= partial "includes/overview/sort" %>


### PR DESCRIPTION
Since we're phasing out this email address, I replaced it with links to the contact form on developer.bestbuy.com.