### PR TITLE
Update contact-us link to pre-fill topic

### DIFF
--- a/source/includes/commerce/_index.md.erb
+++ b/source/includes/commerce/_index.md.erb
@@ -1,5 +1,5 @@
 # Commerce API
-The Best Buy Commerce API allows our partners to introduce a seamless cart experience to their customers, exposing the ability to select various fulfillment options including *Store Pickup* at one of our 1,400+ locations, *Ship To Home* and *Home Delivery*. If you have not yet been issued a Commerce API key, please [contact us](https://developer.bestbuy.com/contact-us).
+The Best Buy Commerce API allows our partners to introduce a seamless cart experience to their customers, exposing the ability to select various fulfillment options including *Store Pickup* at one of our 1,400+ locations, *Ship To Home* and *Home Delivery*. If you have not yet been issued a Commerce API key, please [contact us](https://developer.bestbuy.com/contact-us?topic=commerce-api).
 
 Within the Commerce APIs, partners have the ability to integrate your e-commerce solution with Best Buy's online experience.
 
@@ -12,4 +12,4 @@ Full documentation supplied once you have a CAPI Key. Commerce API functionality
 * Modify/Cancel an Order
 
 ## Getting a Commerce API Key
-Please [contact us](https://developer.bestbuy.com/contact-us) to request an invite to the Commerce API program and a corresponding API Key. Current CAPI partners can access reporting and documentation via the same address.
+Please [contact us](https://developer.bestbuy.com/contact-us?topic=commerce-api) to request an invite to the Commerce API program and a corresponding API Key. Current CAPI partners can access reporting and documentation via the same address.


### PR DESCRIPTION
This updates the links to our contact form that originate from the Commerce API section of the documentation so that the topic and subject are pre-filled when the contact form loads.